### PR TITLE
fix: Jest fetch configuration

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,5 +4,6 @@ const path = require('path');
 module.exports = {
 	preset: 'ts-jest',
 	rootDir: '..',
-	testEnvironment: 'jsdom'
+	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: ['./test/jest.setup.ts']
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-storybook": "^0.8.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "postcss": "^8.4.35",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^16.0.1",

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,14 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+/**
+ * `fetch` polyfill for Jest
+ *
+ * Despite `Jest` `jsdom` providing a browser-like interface for
+ * testing, it does not implement the `fetch` API. This leads to
+ * `fetch is not defined` errors when running tests that use `fetch`.
+ *
+ * `jest-fetch-mock` is a library that provides a `fetch` polyfill
+ * for Jest. It mocks the `fetch` API and allows you to write tests
+ * that use `fetch` without errors.
+ */
+enableFetchMocks()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "./**/*.tsx"
   ],
   "compilerOptions": {
+    "verbatimModuleSyntax": false,
     "strictNullChecks": true,
     "paths": {
       "~*": [


### PR DESCRIPTION
In this project we are running Jest in jsdom environment (we are testing a web browser application).

JSDom does not implement the fetch web browser interface by default, which means we need to Polyfill it so we can run tests which perform calls to the method.

In this commit I am installing `jest-fetch-mock`; a library that makes it easy to mock HTTP requests.

In the future I would like to set up tests in a way they do perform actual HTTP requests rather than faking it, for a closer test experience for the end system, but for now this is a good solution to start writing tests.