### PR TITLE
feat: PDF document download logic.

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,6 +4,18 @@ const path = require('path');
 module.exports = {
 	preset: 'ts-jest',
 	rootDir: '..',
-	testEnvironment: 'jsdom',
+	/**
+	 * Using `node` environment instead of `jsdom` to avoid web browser
+	 * network security restrictions when downloading and uploading files.
+	 *
+	 * The reMarkable Cloud API and web browsers contain certain security
+	 * restrictions when it comes to downloading and uploading files. These
+	 * restrictions are not present in the service worker browser extensions
+	 * use.
+	 *
+	 * To emulate a test environment which is closer to our experience with
+	 * the service worker running environment we use the `node` environment.
+	 */
+	testEnvironment: 'node',
 	setupFilesAfterEnv: ['./test/jest.setup.ts']
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "package": "plasmo package"
   },
   "dependencies": {
+    "cross-fetch": "^4.0.0",
     "plasmo": "0.85.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/src/lib/fileTransfer/WebPdfDocument.ts
+++ b/src/lib/fileTransfer/WebPdfDocument.ts
@@ -1,0 +1,49 @@
+import fetch from 'cross-fetch'
+
+export class InvalidPdfWebDocumentUrlError extends Error {}
+
+export class WebPdfDocumentDownloadError extends Error {}
+
+export class WebPdfDocument {
+  static valid (documentUrl: string): boolean {
+    return documentUrl.endsWith('.pdf')
+  }
+
+  static async initialize (documentUrl: string, name: string): Promise<WebPdfDocument> {
+    if (!WebPdfDocument.valid(documentUrl)) {
+      throw new InvalidPdfWebDocumentUrlError(`Attempt to initialize a WebPdfDocument with an URL whose extension is not PDF: ${documentUrl}`)
+    }
+
+    const downloadResponse = await fetch(documentUrl)
+
+    if (!downloadResponse.ok) {
+      throw new WebPdfDocumentDownloadError(`Failed to download PDF document from URL ${documentUrl}: ${await downloadResponse.text()}`)
+    }
+
+    const buffer = await downloadResponse.arrayBuffer()
+
+    return new WebPdfDocument(buffer, name)
+  }
+
+  readonly #buffer: ArrayBuffer
+  readonly #name: string
+  readonly #size: number
+
+  constructor (buffer: ArrayBuffer, name: string) {
+    this.#buffer = buffer
+    this.#name = name
+    this.#size = buffer.byteLength
+  }
+
+  get buffer (): ArrayBuffer {
+    return this.#buffer
+  }
+
+  get name (): string {
+    return this.#name
+  }
+
+  get size (): number {
+    return this.#size
+  }
+}

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -12,3 +12,8 @@ import { enableFetchMocks } from 'jest-fetch-mock'
  * that use `fetch` without errors.
  */
 enableFetchMocks()
+
+/**
+ * Ensure that `fetch` mock is disabled by default
+ */
+fetchMock.disableMocks()

--- a/test/lib/fileTransfer/WebPdfDocument.test.ts
+++ b/test/lib/fileTransfer/WebPdfDocument.test.ts
@@ -1,0 +1,52 @@
+import {
+  InvalidPdfWebDocumentUrlError,
+  WebPdfDocument,
+  WebPdfDocumentDownloadError
+} from '../../../src/lib/fileTransfer/WebPdfDocument'
+
+describe('WebPdfDocument', () => {
+  describe('#valid', () => {
+    it('if URL refers to a PDF file, returns true', () => {
+      expect(WebPdfDocument.valid('http://example.com/document.pdf')).toBe(true)
+    })
+
+    it('if URL refers to a PDF file, returns true', () => {
+      expect(WebPdfDocument.valid('http://example.com/document.epub')).toBe(false)
+    })
+  })
+
+  describe('#initialize', () => {
+    it(`
+      if PDF URL is given,
+        and URL endpoint contains a PDF,
+          creates WebPdfDocument with PDF file
+    `, async () => {
+      const document = await WebPdfDocument.initialize(
+        'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+        'dummy'
+      )
+
+      expect(document.name).toBe('dummy')
+      expect(document.size).toBe(13264)
+    })
+
+    it(`
+      if non-PDF URL is given,
+          throws invalid PDF URL error
+    `, async () => {
+      await expect(
+        WebPdfDocument.initialize('https://example.com/document.epub', 'dummy')
+      ).rejects.toThrow(InvalidPdfWebDocumentUrlError)
+    })
+
+    it(`
+      if PDF URL is given,
+        and PDF download request is not successful,
+          throws PDF download error
+    `, async () => {
+      await expect(
+        WebPdfDocument.initialize('https://example.com/i-dont-exists.pdf', 'dummy')
+      ).rejects.toThrow(WebPdfDocumentDownloadError)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6789,6 +6789,20 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
+cross-fetch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -9464,6 +9478,14 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
@@ -10689,7 +10711,7 @@ node-fetch-native@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.4.tgz#679fc8fd8111266d47d7e72c379f1bed9acff06e"
   integrity sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==
 
-node-fetch@^2.0.0:
+node-fetch@^2.0.0, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -11761,6 +11783,11 @@ progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1, prompts@^2.4.0:
   version "2.4.2"


### PR DESCRIPTION
The `WebPdfDocument` class extracts the `ArrayBuffer` from a PDF url by downloading it. It also ensures URLs point to valid PDF files. This makes it possible to them pass it down to the reMarkable client, which handles the buffer to upload the file.

On top of that, the Jest configuration has been changed. Now we use Node environment to skip the web-browser restrictions when downloading files, and `cross-fetch` so we use different HTTP clients in Node and Web Browser environments under the same `fetch` interface.