### PR TITLE
feat: Upload Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Run tests
         run: yarn test
+        env:
+          DEVICE_TOKEN: ${{ secrets.DEVICE_TOKEN }}
   lint:
     environment: test
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist/
 
 # RubyMine Configuration
 .idea/*
+.env.test

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
     "autoprefixer": "^10.4.18",
+    "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "eslint-config-standard-with-typescript": "^43.0.1",
     "eslint-plugin-import": "^2.29.1",

--- a/src/lib/fileTransfer/UploadManager.ts
+++ b/src/lib/fileTransfer/UploadManager.ts
@@ -1,0 +1,25 @@
+import { type DocumentReference, RemarkableClient } from 'a-remarkable-js-sdk'
+import { WebPdfDocument } from './WebPdfDocument'
+
+export default class UploadManager {
+  readonly #reMarkableClient: RemarkableClient
+
+  constructor (
+    deviceToken: string,
+    sessionToken?: string
+  ) {
+    this.#reMarkableClient = RemarkableClient.withFetchHttpClient(deviceToken, sessionToken)
+  }
+
+  async upload (name: string, documentUrl: string): Promise<DocumentReference> {
+    if (this.#reMarkableClient.sessionExpired) {
+      await this.#reMarkableClient.connect()
+    }
+
+    const webDocument = await WebPdfDocument.initialize(documentUrl, name)
+
+    const documentReference = await this.#reMarkableClient.upload(name, webDocument.buffer)
+
+    return documentReference
+  }
+}

--- a/src/lib/fileTransfer/WebPdfDocument.ts
+++ b/src/lib/fileTransfer/WebPdfDocument.ts
@@ -25,18 +25,20 @@ export class WebPdfDocument {
     return new WebPdfDocument(buffer, name)
   }
 
-  readonly #buffer: ArrayBuffer
+  readonly #arrayBuffer: ArrayBuffer
   readonly #name: string
-  readonly #size: number
 
-  constructor (buffer: ArrayBuffer, name: string) {
-    this.#buffer = buffer
+  constructor (arrayBuffer: ArrayBuffer, name: string) {
+    this.#arrayBuffer = arrayBuffer
     this.#name = name
-    this.#size = buffer.byteLength
   }
 
-  get buffer (): ArrayBuffer {
-    return this.#buffer
+  get arrayBuffer (): ArrayBuffer {
+    return this.#arrayBuffer
+  }
+
+  get buffer (): Buffer {
+    return Buffer.from(this.#arrayBuffer)
   }
 
   get name (): string {
@@ -44,6 +46,6 @@ export class WebPdfDocument {
   }
 
   get size (): number {
-    return this.#size
+    return this.#arrayBuffer.byteLength
   }
 }

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,4 +1,10 @@
+import * as dotenv from 'dotenv'
 import { enableFetchMocks } from 'jest-fetch-mock'
+
+/**
+ * jest-fetch-mock Configuration
+ * -----------------------------
+ */
 
 /**
  * `fetch` polyfill for Jest
@@ -17,3 +23,13 @@ enableFetchMocks()
  * Ensure that `fetch` mock is disabled by default
  */
 fetchMock.disableMocks()
+
+/**
+ * DotEnv Configuration
+ * --------------------
+ */
+
+/**
+ * Load environment variables from .env.test file
+ */
+dotenv.config({ path: '.env.test' })

--- a/test/lib/fileTransfer/UploadManager.test.ts
+++ b/test/lib/fileTransfer/UploadManager.test.ts
@@ -1,0 +1,21 @@
+import UploadManager from '../../../src/lib/fileTransfer/UploadManager'
+
+describe('UploadManager', () => {
+  describe('.upload', () => {
+    it(
+      `
+      if document URL is valid, uploads document to reMarkable Cloud
+    `,
+      async () => {
+        const uploadManager = new UploadManager(process.env.DEVICE_TOKEN!)
+
+        const documentReference = await uploadManager.upload(
+          'dummy',
+          'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
+        )
+
+        expect(documentReference).toBeDefined()
+      }
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7310,7 +7310,7 @@ dotenv@16.3.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
-dotenv@^16.0.0:
+dotenv@^16.0.0, dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==


### PR DESCRIPTION
Defines a service to upload PDF documents to the reMarkable Cloud through its URL.

The reMarkable Client expects a Buffer to be provided when uploading. Thus I needed to tweat the WebPdfDocument interface to return a Buffer object from its ArrayBuffer.