### PR TITLE
feat: Icon Button component

### DIFF
--- a/src/components/common/iconButton.stories.tsx
+++ b/src/components/common/iconButton.stories.tsx
@@ -1,0 +1,34 @@
+import IconButton, { ICON_BUTTON_SIZES, ICON_BUTTON_STYLES, type IconButtonProps } from './iconButton'
+import { type StoryFn } from '@storybook/react'
+
+export default {
+  title: 'Common/IconButton',
+  component: IconButton,
+  argTypes: {
+    as: {
+      control: 'select',
+      options: ['button', 'a', 'div']
+    },
+    theme: {
+      control: 'select',
+      options: Object.keys(ICON_BUTTON_STYLES)
+    },
+    size: {
+      control: 'select',
+      options: Object.keys(ICON_BUTTON_SIZES)
+    }
+  }
+}
+
+const Template: StoryFn<IconButtonProps> = (args) => <IconButton {...args} />
+
+export const Playground = Template.bind({})
+
+export const Small = Template.bind({})
+Small.args = { size: 'small' }
+
+export const Medium = Template.bind({})
+Medium.args = { size: 'medium' }
+
+export const Primary = Template.bind({})
+Primary.args = { theme: 'primary' }

--- a/src/components/common/iconButton.tsx
+++ b/src/components/common/iconButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+export interface IconButtonProps {
+  as?: 'button' | 'a' | 'div'
+  theme?: 'primary'
+  size?: 'small' | 'medium' | 'large'
+  [x: string]: unknown
+}
+
+export const ICON_BUTTON_STYLES = {
+  primary: `
+    border border-gray-700 text-gray-700 font-semibold
+    hover:bg-gray-700 hover:text-white
+    disabled:bg-gray-300 disabled:text-gray-300
+  `
+}
+
+export const ICON_BUTTON_SIZES = {
+  small: 'h-[24px] w-[24px] text-xs',
+  medium: 'h-[38px] w-[38px] text-base'
+}
+
+export default function Button ({ as, theme, size, ...rest }: IconButtonProps): React.ReactElement {
+  const Component = as ?? 'button'
+  const className = `
+    flex items-center justify-center
+    transition-all cursor-pointer disabled:cursor-not-allowed
+    ${ICON_BUTTON_STYLES[theme ?? 'primary']}
+    ${ICON_BUTTON_SIZES[size ?? 'medium']}
+  `
+
+  return (
+    <Component
+      className = {className}
+      {...rest}
+    >
+      a
+    </Component>
+  )
+}


### PR DESCRIPTION
Adds a first version of the icon button component.

Due to some issues importing SVGs, I will leave the inclusion of icons for another PR. For now it is just about a basic layout for the component, so I can use it in the upload widget.