### PR TITLE
feat: SVG icons in icon button component.

### DIFF
--- a/src/components/common/icon.tsx
+++ b/src/components/common/icon.tsx
@@ -25,13 +25,13 @@ export interface IconProps {
 
 export const ICON_SIZES = {
   xs: 'w-4 h-4',
-  sm: 'w-6 h-6',
+  sm: 'w-5 h-5',
   base: 'w-8 h-8',
   lg: 'w-12 h-12'
 }
 
-export default function Icon ({ icon, size, className }: IconProps): React.ReactElement {
-  const iconClasses = `${ICON_SIZES[size ?? 'medium']}} ${className as string | null}`
+export default function Icon ({ icon, size, ...rest }: IconProps): React.ReactElement {
+  const iconClasses = `${ICON_SIZES[size ?? 'medium']} ${rest.className as string | null}`
 
   return <div className={iconClasses} dangerouslySetInnerHTML={{ __html: ICONS_LIBRARY[icon] }} />
 }

--- a/src/components/common/iconButton.stories.tsx
+++ b/src/components/common/iconButton.stories.tsx
@@ -1,11 +1,16 @@
 import { type StoryFn } from '@storybook/react'
 
 import IconButton, { ICON_BUTTON_SIZES, ICON_BUTTON_STYLES, type IconButtonProps } from './iconButton'
+import { ICONS_LIBRARY } from './icon'
 
 export default {
   title: 'Common/IconButton',
   component: IconButton,
   argTypes: {
+    icon: {
+      control: 'select',
+      options: Object.keys(ICONS_LIBRARY)
+    },
     as: {
       control: 'select',
       options: ['button', 'a', 'div']
@@ -26,10 +31,10 @@ const Template: StoryFn<IconButtonProps> = (args) => <IconButton {...args} />
 export const Playground = Template.bind({})
 
 export const Small = Template.bind({})
-Small.args = { size: 'small' }
+Small.args = { size: 'sm', icon: 'upload' }
 
 export const Medium = Template.bind({})
-Medium.args = { size: 'medium' }
+Medium.args = { size: 'base', icon: 'upload' }
 
 export const Primary = Template.bind({})
-Primary.args = { theme: 'primary' }
+Primary.args = { theme: 'primary', icon: 'upload' }

--- a/src/components/common/iconButton.tsx
+++ b/src/components/common/iconButton.tsx
@@ -1,27 +1,45 @@
 import React from 'react'
 
+import Icon, { type IconProps } from './icon'
+
 export interface IconButtonProps {
+  icon: 'upload'
   as?: 'button' | 'a' | 'div'
   theme?: 'primary'
-  size?: 'small' | 'medium' | 'large'
+  size?: 'sm' | 'base'
   [x: string]: unknown
 }
 
 export const ICON_BUTTON_STYLES = {
   primary: `
-    border border-gray-700 text-gray-700 font-semibold
+    group/button
+    border border-gray-700 text-gray-700  font-semibold
     hover:bg-gray-700 hover:text-white
     disabled:bg-gray-300 disabled:text-gray-300
   `
 }
 
-export const ICON_BUTTON_SIZES = {
-  small: 'h-[24px] w-[24px] text-xs',
-  medium: 'h-[38px] w-[38px] text-base'
+export const ICON_BUTTON_ICON_STYLES = {
+  primary: `
+    text-gray-700
+    group-hover/button:text-white
+    group-disabled/button:text-gray-300
+  `
 }
 
-export default function Button ({ as, theme, size, ...rest }: IconButtonProps): React.ReactElement {
+export const ICON_BUTTON_SIZES = {
+  sm: 'h-[24px] w-[24px]',
+  base: 'h-[34px] w-[34px]'
+}
+
+export const ICON_BUTTON_ICON_SIZES = {
+  sm: 'xs',
+  base: 'sm'
+}
+
+export default function Button ({ icon, as, theme, size, ...rest }: IconButtonProps): React.ReactElement {
   const Component = as ?? 'button'
+
   const className = `
     flex items-center justify-center
     transition-all cursor-pointer disabled:cursor-not-allowed
@@ -29,12 +47,15 @@ export default function Button ({ as, theme, size, ...rest }: IconButtonProps): 
     ${ICON_BUTTON_SIZES[size ?? 'medium']}
   `
 
+  const iconProps = {
+    icon,
+    className: ICON_BUTTON_ICON_STYLES[theme ?? 'primary'],
+    size: ICON_BUTTON_ICON_SIZES[size ?? 'base'] as 'xs' | 'sm' | 'base' | 'lg'
+  } satisfies IconProps
+
   return (
-    <Component
-      className = {className}
-      {...rest}
-    >
-      a
+    <Component className = {className} {...rest}>
+      <Icon {...iconProps}/>
     </Component>
   )
 }


### PR DESCRIPTION
Now the SVGs are working and encapsulated in components I can replace the previous placeholder by actual icons.

I updated the IconButton props and stories to select specific icons, and extended the styling logic to properly customize the icon inside it.