### PR TITLE
feat: `getDocumentPreview` message for background script.

### DIFF
--- a/src/background/messages/getDocumentPreview.ts
+++ b/src/background/messages/getDocumentPreview.ts
@@ -1,0 +1,28 @@
+import * as DocumentPreviewSerializer from '../../lib/serializers/documentPreview'
+import type { PlasmoMessaging } from '@plasmohq/messaging'
+import DocumentPreview from '../../lib/models/DocumentPreview'
+import Message from '../../lib/utils/Message'
+
+export interface GetDocumentPreviewMessageRequestPayload {
+  url: string
+}
+
+export interface GetDocumentPreviewMessageResponsePayload {
+  url: string
+  size: number
+}
+
+class GetDocumentPreviewMessage extends Message {
+  protected async process (request: PlasmoMessaging.Request): Promise<GetDocumentPreviewMessageResponsePayload> {
+    const payload = request.body as GetDocumentPreviewMessageRequestPayload
+    const documentPreview = await DocumentPreview.from(payload.url)
+    return DocumentPreviewSerializer.serialize(documentPreview)
+  }
+}
+
+const handler: PlasmoMessaging.MessageHandler = async (request, response) => {
+  const message = new GetDocumentPreviewMessage()
+  await message.handle(request, response)
+}
+
+export default handler

--- a/src/lib/serializers/documentPreview.ts
+++ b/src/lib/serializers/documentPreview.ts
@@ -1,0 +1,17 @@
+import DocumentPreview from '../models/DocumentPreview'
+
+export interface SerializedDocumentPreview {
+  url: string
+  size: number
+}
+
+export function serialize (documentPreview: DocumentPreview): SerializedDocumentPreview {
+  return {
+    url: documentPreview.url,
+    size: documentPreview.size
+  }
+}
+
+export function deserialize (documentPreviewPayload: SerializedDocumentPreview): DocumentPreview {
+  return new DocumentPreview(documentPreviewPayload.url, documentPreviewPayload.size)
+}


### PR DESCRIPTION
In order to get the full preview information of a web document (such as size), we need to perform certain HTTP requests which cannot be executed in the browser environment, but in the background worker environment.

With this message we allow elements from the web browser environment to request document previews by delegating the task to a background worker.