### PR TITLE
feat: upload widget content script

### DIFF
--- a/src/background/messages/pair.ts
+++ b/src/background/messages/pair.ts
@@ -11,8 +11,8 @@ export interface PairMessageResponsePayload {
 
 class PairMessage extends Message {
   protected async process (request: PlasmoMessaging.Request): Promise<PairMessageResponsePayload> {
-    const payload = request.body as PairMessageRequestPayload
-    const deviceToken = await this.pairManager.pair(payload.oneTimeCode)
+    const { oneTimeCode } = request.body as PairMessageRequestPayload
+    const deviceToken = await this.pairManager.pair(oneTimeCode)
     return { deviceToken }
   }
 }

--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -23,6 +23,7 @@ export default function Button ({ as, variant, size, children, ...rest }: Button
   const Component = as ?? 'button'
 
   const className = `
+    flex items-center justify-center
     transition-all cursor-pointer disabled:cursor-not-allowed
     ${BUTTON_VARIANTS[variant ?? 'primary']}
     ${BUTTON_SIZES[size ?? 'medium']}

--- a/src/components/contents/uploadButton.tsx
+++ b/src/components/contents/uploadButton.tsx
@@ -62,7 +62,7 @@ export default function UploadButton ({ documentPreview, uploadDocument }: Uploa
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
-    placement: 'top-end',
+    placement: 'top-start',
     middleware: [
       offset(10),
       flip({ fallbackAxisSideDirection: 'end' }),

--- a/src/components/contents/uploadButton.tsx
+++ b/src/components/contents/uploadButton.tsx
@@ -78,9 +78,9 @@ export default function UploadButton ({ documentPreview, uploadDocument }: Uploa
 
   return (
     <div className='w-fit'>
-      <div className='group/upload-button w-fit inline-flex' ref={refs.setReference} {...getReferenceProps()}>
+      <div className='group/upload-button w-[325px] pointer-events-none w-fit inline-flex' ref={refs.setReference} {...getReferenceProps()}>
         <IconButton
-          className='border-r-0'
+          className='border-r-0 pointer-events-auto'
           icon={ BUTTON_ICON[uploadStatus] }
           onClick={async (): Promise<void> => { await startUpload() }}
           size='sm'
@@ -88,7 +88,7 @@ export default function UploadButton ({ documentPreview, uploadDocument }: Uploa
         <Button
           className={
             `
-              border-l-0 inline-flex items-center justify-center gap-2 text-nowrap
+              border-l-0 inline-flex items-center justify-center gap-2 text-nowrap pointer-events-auto
               animate-all ease-out duration-400 overflow-hidden !w-0 !px-0
               group-hover/upload-button:!w-[200px] group-hover/upload-button:!px-4
             `

--- a/src/components/contents/uploadPreview.tsx
+++ b/src/components/contents/uploadPreview.tsx
@@ -24,7 +24,7 @@ export default function UploadOverview ({ documentPreview, fileName, setFileName
       <div className='inline-flex gap-2 pb-4'>
         <Icon icon='document' size='xs'/>
         <div className='flex-1'>
-          <p className="text-gray-700">{uploadFileName}</p>
+          <p className="text-gray-700">{documentPreview?.name}</p>
           <p className='font-thin space-x-1'>
             <span>url:</span>
             <a href={documentPreview?.url} target='_blank' rel='noreferrer'

--- a/src/components/contents/uploadPreview.tsx
+++ b/src/components/contents/uploadPreview.tsx
@@ -20,7 +20,7 @@ export default function UploadOverview ({ documentPreview, fileName, setFileName
 
   // TODO: horizontal description list & input component with labels
   return (
-    <div className="w-[300px] px-4 py-3 divide-y divide-dashed text-xs text-gray-400 border border-gray-700">
+    <div className="w-[300px] px-4 py-3 divide-y divide-dashed !bg-white text-xs text-gray-400 border border-gray-700">
       <div className='inline-flex gap-2 pb-4'>
         <Icon icon='document' size='xs'/>
         <div className='flex-1'>

--- a/src/components/options/deviceConnector.tsx
+++ b/src/components/options/deviceConnector.tsx
@@ -45,7 +45,7 @@ function DeviceConnector ({ pair }: DeviceConnectorProps): React.ReactElement {
         and the extension
       </p>
 
-      <Button as="a" href="https://my.remarkable.com/device/remarkable" target="_blank">
+      <Button as="a" size="base" href="https://my.remarkable.com/device/remarkable" target="_blank">
         request one time code
       </Button>
 

--- a/src/components/options/settings.tsx
+++ b/src/components/options/settings.tsx
@@ -20,7 +20,7 @@ function Settings ({ device, unpair }: SettingsProps): React.ReactElement {
         <DescriptionList listItems={ { Device: device.id, 'Connected at': '12.12.2024' } }/>
 
         <div className="w-full inline-flex gap-4 justify-center">
-          <Button onClick={unpair}>Disconnect</Button>
+          <Button size="base" onClick={unpair}>Disconnect</Button>
         </div>
       </div>
     </div>

--- a/src/components/popup/welcome.tsx
+++ b/src/components/popup/welcome.tsx
@@ -11,7 +11,7 @@ function Welcome (): React.ReactElement {
         your device with this extension
       </p>
 
-      <Button as="a" href={`chrome-extension://${chrome?.runtime?.id}/options.html`} target="_blank">
+      <Button as="a" size="base" href={`chrome-extension://${chrome?.runtime?.id}/options.html`} target="_blank">
         open extension settings
       </Button>
     </div>

--- a/src/contents/uploadWidget.tsx
+++ b/src/contents/uploadWidget.tsx
@@ -3,8 +3,8 @@ import type { PlasmoGetOverlayAnchor } from 'plasmo'
 import React, { useEffect, useRef, useState } from 'react'
 
 import DocumentPreview from '../lib/models/DocumentPreview'
+import { type GetDocumentPreviewMessageResponsePayload } from '../background/messages/getDocumentPreview'
 import UploadButton from '../components/contents/uploadButton'
-
 import styleText from 'data-text:../../assets/css/style.css'
 import { UPLOAD_WIDGET_ANCHOR_ID } from '../lib/ui/uploadWidget/AnchorTrackingManager'
 
@@ -21,7 +21,14 @@ export const getOverlayAnchor: PlasmoGetOverlayAnchor = async () => {
 
 export default function UploadWidget ({ anchor: { element } }): React.ReactElement {
   const [documentPreview, setDocumentPreview] = useState<DocumentPreview | undefined>(undefined)
-  const [fileName, setFileName] = useState<string | null>(null)
+
+  async function uploadDocument (fileName: string, url: string): Promise<void> {
+    await sendToBackground({
+      name: 'upload',
+      body: { name: fileName, webDocumentUrl: url },
+      extensionId: 'egdpalgnbmgehpebjmkklcfkggadmglp'
+    })
+  }
 
   const widgetWrapperRef = useRef<HTMLDivElement>(null)
   const widgetButtonRef = useRef<HTMLDivElement>(null)
@@ -59,9 +66,7 @@ export default function UploadWidget ({ anchor: { element } }): React.ReactEleme
   return (
     <div ref={widgetWrapperRef} className={ `relative pointer-events-none animate-all ${documentPreview != null ? 'opacity-1' : 'hidden'}` }>
       <div ref={widgetButtonRef} className="pl-3 pointer-events-auto">
-        <UploadButton
-          documentPreview={documentPreview}
-          setFileName={setFileName}/>
+        {documentPreview != null && <UploadButton documentPreview={documentPreview} uploadDocument={uploadDocument}/>}
       </div>
     </div>
   )

--- a/src/contents/uploadWidget.tsx
+++ b/src/contents/uploadWidget.tsx
@@ -1,0 +1,68 @@
+import { sendToBackground } from '@plasmohq/messaging'
+import type { PlasmoGetOverlayAnchor } from 'plasmo'
+import React, { useEffect, useRef, useState } from 'react'
+
+import DocumentPreview from '../lib/models/DocumentPreview'
+import UploadButton from '../components/contents/uploadButton'
+
+import styleText from 'data-text:../../assets/css/style.css'
+import { UPLOAD_WIDGET_ANCHOR_ID } from '../lib/ui/uploadWidget/AnchorTrackingManager'
+
+export const getStyle = (): HTMLElement => {
+  const style = document.createElement('style')
+  style.textContent = styleText
+  return style
+}
+
+// @ts-expect-error - Expected Error
+export const getOverlayAnchor: PlasmoGetOverlayAnchor = async () => {
+  return document.querySelector(`#${UPLOAD_WIDGET_ANCHOR_ID}`)
+}
+
+export default function UploadWidget ({ anchor: { element } }): React.ReactElement {
+  const [documentPreview, setDocumentPreview] = useState<DocumentPreview | undefined>(undefined)
+  const [fileName, setFileName] = useState<string | null>(null)
+
+  const widgetWrapperRef = useRef<HTMLDivElement>(null)
+  const widgetButtonRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    async function fetchDocumentPreview (): Promise<void> {
+      const documentPreviewResponse: GetDocumentPreviewMessageResponsePayload =
+        await sendToBackground(
+          {
+            name: 'getDocumentPreview',
+            body: { url: element.href },
+            extensionId: 'egdpalgnbmgehpebjmkklcfkggadmglp'
+          }
+        )
+
+      const { url, size } = documentPreviewResponse
+
+      setDocumentPreview(new DocumentPreview(url, size))
+    }
+
+    void fetchDocumentPreview().then(r => {})
+  }, [])
+
+  useEffect(() => {
+    const widgetWrapper = widgetWrapperRef.current as HTMLDivElement
+    const widgetButton = widgetButtonRef.current as HTMLDivElement
+
+    // Updates widget wrapper to match the anchor element's position
+    widgetWrapper.style.width = `${element.offsetWidth}px`
+
+    // Update button wrapper to position it around the widget wrapper
+    widgetButton.style.marginLeft = `${element.offsetWidth}px`
+  })
+
+  return (
+    <div ref={widgetWrapperRef} className={ `relative pointer-events-none animate-all ${documentPreview != null ? 'opacity-1' : 'hidden'}` }>
+      <div ref={widgetButtonRef} className="pl-3 pointer-events-auto">
+        <UploadButton
+          documentPreview={documentPreview}
+          setFileName={setFileName}/>
+      </div>
+    </div>
+  )
+}

--- a/src/contents/uploadWidgetAnchoring.ts
+++ b/src/contents/uploadWidgetAnchoring.ts
@@ -1,0 +1,12 @@
+/**
+ * Script to attach the upload widget component to DOM elements containing
+ * references to downloadable documents compatible with the reMarkable Cloud
+ */
+
+import AnchorTrackingManager from '../lib/ui/uploadWidget/AnchorTrackingManager'
+
+export {}
+
+// TODO: display only once the extension is paired to a remarkable device
+// eslint-disable-next-line no-new
+new AnchorTrackingManager(document.body)

--- a/src/lib/services/remarkable/PairManager.ts
+++ b/src/lib/services/remarkable/PairManager.ts
@@ -3,9 +3,8 @@ import RemarkableManager from './RemarkableManager'
 
 export default class PairManager extends RemarkableManager {
   async pair (oneTimeCode: string): Promise<string> {
-    const client = await this.remarkableClient()
+    const client = await this.remarkableUnpairedClient()
     await client.pair(uuidv4(), 'browser-chrome', oneTimeCode)
-    // TODO: device token should be returned after pairing, here the connection manager knows too much
     await this.authenticationManager.setNewDevice(client.device.token)
     return client.device.token
   }

--- a/src/lib/services/remarkable/RemarkableManager.ts
+++ b/src/lib/services/remarkable/RemarkableManager.ts
@@ -43,4 +43,8 @@ export default abstract class RemarkableManager {
 
     return client
   }
+
+  protected async remarkableUnpairedClient (): Promise<RemarkableClient> {
+    return new RemarkableClient()
+  }
 }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -14,7 +14,7 @@ function Options (): React.ReactElement {
   const [device, setDevice] = useState<Device | null>(null)
 
   const pair = useCallback(async (oneTimeCode: string): Promise<Device | null> => {
-    const pairResponse: PairMessageResponsePayload = await sendToBackground({ name: 'pair' })
+    const pairResponse: PairMessageResponsePayload = await sendToBackground({ name: 'pair', body: { oneTimeCode } })
     const device = new Device(pairResponse.deviceToken)
     setDevice(device)
     return device


### PR DESCRIPTION
Defines a content script displaying the upload button next to link elements pointing to PDF documents, allowing users to upload files to the reMarkable Cloud in one click.