### PR TITLE
feat: Extension Manager

### DIFF
--- a/src/background/messages/getExtensionMetadata.ts
+++ b/src/background/messages/getExtensionMetadata.ts
@@ -1,0 +1,22 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging'
+
+import ExtensionManager from '../../lib/services/ExtensionManager'
+import Message from '../../lib/utils/Message'
+
+export interface GetExtensionMetadataResponsePayload {
+  id: string
+}
+
+class GetExtensionMetadataMessage extends Message {
+  protected async process (request: PlasmoMessaging.Request): Promise<GetExtensionMetadataResponsePayload> {
+    const extensionManager = new ExtensionManager()
+    return { id: extensionManager.extensionId }
+  }
+}
+
+const handler: PlasmoMessaging.MessageHandler = async (request, response) => {
+  const message = new GetExtensionMetadataMessage()
+  await message.handle(request, response)
+}
+
+export default handler

--- a/src/lib/services/ExtensionManager.ts
+++ b/src/lib/services/ExtensionManager.ts
@@ -1,0 +1,22 @@
+declare let browser: typeof chrome
+
+export default class ExtensionManager {
+  readonly #runtime: unknown
+
+  constructor () {
+    this.#runtime = this.#browser.runtime
+  }
+
+  get extensionId (): string {
+    // @ts-expect-error - expected error
+    return this.#runtime.id
+  }
+
+  get #browser (): typeof browser | typeof chrome {
+    if (typeof browser !== 'undefined') {
+      return browser
+    } else {
+      return chrome
+    }
+  }
+}


### PR DESCRIPTION
Add a service to extract extension information (such as ID). Update service message to request extension metadata and fetch ID from manager instead. Update message manager logic, to now only use static methods for sending messages.